### PR TITLE
Add support for only showing translated text

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "@augmentos/livetrasnlation",
+      "name": "@augmentos/livetranslation",
       "dependencies": {
         "@augmentos/sdk": "^1.1.2",
         "@node-rs/jieba": "^2.0.1",

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: docker/Dockerfile.dev
     container_name: live-translation-dev2
     ports:
-      - "8070:80"
+      - "8071:80"
     volumes:
       - ../src:/app/src:delegated
       - ../scripts:/app/scripts:delegated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@augmentos/livetrasnlation",
+  "name": "@augmentos/livetranslation",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@augmentos/livetrasnlation",
+      "name": "@augmentos/livetranslation",
       "version": "1.0.0",
       "dependencies": {
         "@augmentos/sdk": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@augmentos/livetrasnlation",
+  "name": "@augmentos/livetranslation",
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {

--- a/src/public/tpa_config.json
+++ b/src/public/tpa_config.json
@@ -182,6 +182,22 @@
                   "value": 5
               }
           ]
+      },
+      {
+          "key": "display_mode",
+          "type": "select",
+          "label": "When to display",
+          "defaultValue": "translations",
+          "options": [
+              {
+                  "label": "Only show translations",
+                  "value": "translations"
+              },
+              {
+                  "label": "Caption everything",
+                  "value": "everything"
+              }
+          ]
       }
   ]
 }


### PR DESCRIPTION
Uses the new translation metadata from https://github.com/AugmentOS-Community/AugmentOS/pull/364 to only show translations when someone is actually speaking in the source language.  Adds a TPA setting to control this behavior change.

Please merge https://github.com/AugmentOS-Community/AugmentOS/pull/364 first, it needs to be in production before this will work!