### PR TITLE
Fix Live Translation to Display Only Target Language on Glasses #992

### DIFF
--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -20,9 +20,9 @@ export default defineConfig({
     },
   },
   server: {
-    allowedHosts: ['live-translation.ngrok.dev', 'isaiah-webview.ngrok.app', 'localhost', 'translation.mentra.glass'],
+    allowedHosts: ['live-translation.ngrok.dev', 'isaiah-webview.ngrok.app', 'webview.ngrok.dev', 'localhost', 'translation.mentra.glass'],
   },
   preview: {
-    allowedHosts: ['live-translation.ngrok.dev', 'isaiah-webview.ngrok.app', 'localhost', 'translation.mentra.glass', "https://webview-10410-4a24a192-ojqv695t.onporter.run"],
+    allowedHosts: ['live-translation.ngrok.dev', 'isaiah-webview.ngrok.app', 'webview.ngrok.dev', 'localhost', 'translation.mentra.glass', "https://webview-10410-4a24a192-ojqv695t.onporter.run"],
   },
 })


### PR DESCRIPTION
Using the live translation will display the source text on the glasses’ display. The translation must be shown in the target language on the glasses.

#992 is to test if linear picks it up

